### PR TITLE
Allow ignore files and set last uploaded commit

### DIFF
--- a/tasks/git_ftp.js
+++ b/tasks/git_ftp.js
@@ -195,6 +195,11 @@ module.exports = function(grunt){
     });
 
     done = this.async();
+	
+	//get all ignored files
+	if (options.ignore) {
+		gruntGitFtpApp.ignoredFiles = grunt.file.expand(options.ignore);
+	}
 
     //get host file 
     if(gruntGitFtpApp.getHostFile(options.host,options.hostFile) === null){
@@ -277,6 +282,10 @@ module.exports = function(grunt){
               //filter array and return remote filepath
               gruntGitFtpApp.localFiles = argLastCommited.filter(function(filepath){
                 if(fs.existsSync(gruntRootPath + '/' + filepath)){ 
+					//skip ignored
+					if (gruntGitFtpApp.ignoredFiles && gruntGitFtpApp.ignoredFiles.indexOf(filepath) > -1) {
+						return false;
+					}
                   //store directory as a key(path) value(successfully uploaded)
                   gruntGitFtpApp.localDirectories[path.normalize(path.dirname(remoteRootPath + '/' + filepath) + '/')] = null;
                   //only return file OR files that start with (.)

--- a/tasks/git_ftp.js
+++ b/tasks/git_ftp.js
@@ -225,7 +225,11 @@ module.exports = function(grunt){
               //get last commited revision number
               gruntGitFtpApp.cmd('git rev-parse --verify HEAD',function(output){
                 //revisionNumber trim and toString
-                gruntGitFtpApp.revisionNumber = output.toString(); 
+                if (grunt.option('commit')) {
+					gruntGitFtpApp.revisionNumber = grunt.option('commit'); 
+				} else {	
+					gruntGitFtpApp.revisionNumber = output.toString(); 
+				}
                 //check string length
                 if(gruntGitFtpApp.revisionNumber.length !== 0){
                   //notify user


### PR DESCRIPTION
- It is possible to ignore files specified in task config:

``` javascript
options: {
    'hostFile': '.ftppass',
    'host': 'default',
    'ignore': ['**/*.less', 'composer.json']
}
```
- Added specifying last uploaded commit, so it is possible to upload via FTP more than just last commit. As parametr is used commit hash:

```
grunt deploy --commit=29c6112
```
